### PR TITLE
fixed pytorch version to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some necessary libraries include:
 pip install numpy scipy matplotlib tensorboard open3d==0.9.0 opencv-python
 pip install "rtree>=0.8,<0.9" 
 pip install trimesh[easy]
-conda install pytorch torchvision cudatoolkit=10.1 -c pytorch
+conda install pytorch-1.6.0 torchvision cudatoolkit=10.1 -c pytorch
 pip install torch-scatter==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
 pip install torch-sparse==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
 pip install torch-cluster==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some necessary libraries include:
 pip install numpy scipy matplotlib tensorboard open3d==0.9.0 opencv-python
 pip install "rtree>=0.8,<0.9" 
 pip install trimesh[easy]
-conda install pytorch-1.6.0 torchvision cudatoolkit=10.1 -c pytorch
+conda install pytorch==1.6.0 torchvision==0.7.0 cudatoolkit=10.1 -c pytorch
 pip install torch-scatter==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
 pip install torch-sparse==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html
 pip install torch-cluster==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.6.0.html


### PR DESCRIPTION
Hey,

like mentioned in #29 

currently after running the dependency setup pytorch is being resolved to 1.7 instead of 1.6.0.
This creates errors down the line when trying to `import torch_geometric`.

Thanks